### PR TITLE
Change timezone input type to 'search', which presents a 'clear' button

### DIFF
--- a/program.css
+++ b/program.css
@@ -323,3 +323,7 @@ div.c button {
 
 h2 { margin: 0 auto; padding: 11px 21px !important; line-height: 1.4rem; font-weight: 400; font-family: "Helvetica Neue", Helvetica, sans-serif; }
 h2:hover { background-color: #666 !important; color: white !important; }
+
+#yourTimeZone {
+  width: 250px;
+}

--- a/program.html
+++ b/program.html
@@ -31,8 +31,7 @@
 </div>
 
 <div class="attention">
-  <h3 class="firstDate laTime"><img class="clockIcon" src="assets/img/icon-clock.png" alt="Current time" />Current local time is <span id="yourTime"></span>, as determined from your browser. All presentation times below are in time zone: <input id="yourTimeZone" list="timezones" type="text"/>.</h3>
-
+  <h3 class="firstDate laTime"><img class="clockIcon" src="assets/img/icon-clock.png" alt="Current time" />Current local time is <span id="yourTime"></span>, as determined from your browser. All presentation times below are in time zone: <input id="yourTimeZone" list="timezones" type="search"/>.</h3>
   <!--
   <h3 class="calendar"><a href="https://tug.org/tug2020/tug2020.ics"><img class="calendarIcon" src="img/icon-calendar.png" alt="Add to calendar" />Download ICS calendar file to add presentation times</a> to your calendar. Instructions <a href="https://tug.org/tug2020/ICS_import.html">here</a>.</h3>
   -->

--- a/program.html.in
+++ b/program.html.in
@@ -31,7 +31,7 @@
 </div>
 
 <div class="attention">
-  <h3 class="firstDate laTime"><img class="clockIcon" src="assets/img/icon-clock.png" alt="Current time" />Current local time is <span id="yourTime"></span>, as determined from your browser. All presentation times below are in time zone: <input id="yourTimeZone" list="timezones" type="text"/>.</h3>
+  <h3 class="firstDate laTime"><img class="clockIcon" src="assets/img/icon-clock.png" alt="Current time" />Current local time is <span id="yourTime"></span>, as determined from your browser. All presentation times below are in time zone: <input id="yourTimeZone" list="timezones" type="search"/>.</h3>
   <!--
   <h3 class="calendar"><a href="https://tug.org/tug2020/tug2020.ics"><img class="calendarIcon" src="img/icon-calendar.png" alt="Add to calendar" />Download ICS calendar file to add presentation times</a> to your calendar. Instructions <a href="https://tug.org/tug2020/ICS_import.html">here</a>.</h3>
   -->


### PR DESCRIPTION
This small change attempts to fix the potential confusion which happens when the timezone datalist is pre-populated. At that state, if you click on the input box or click the little triangle icon, you'll see only one item listed. In order to see the rest of the list you'd have to delete the content of the input box.

Changing the input type from `text` to `search`, so that a small `X` icon appears when the input box has content.