### PR TITLE
Highlight the current active session

### DIFF
--- a/program.css
+++ b/program.css
@@ -327,3 +327,15 @@ h2:hover { background-color: #666 !important; color: white !important; }
 #yourTimeZone {
   width: 250px;
 }
+
+h2.active-session {
+  color: #fff;
+  animation: blinkingBackground 2s infinite;
+}
+
+@keyframes blinkingBackground{
+  0%    { background-color: #10c018;}
+  30%	  { background-color: #1056c0;}
+  60%	  { background-color: #ef0a1a;}
+  100%  { background-color: #04a1d5;}
+}

--- a/program.html
+++ b/program.html
@@ -804,7 +804,7 @@ $( document ).ready(function() {
 
     timezone.oninput = function () {
         moment.tz.setDefault(this.value)
-        set_local_time()
+        setLocalTime()
     }
     const poshletClasses = ".latex, .tex, .xetexwithsub, .xetex, .xesomething";
 
@@ -820,7 +820,52 @@ $( document ).ready(function() {
         $('#yourTime').html(timeString);
     }
 
-    function set_local_time() {
+    /**
+     * Goes through all items (sessions) and marks the 'current' one as "active-session".
+     * This would affect its appearance (blinking background)
+     */
+    function markActiveSession() {
+        var prevSession = {};
+
+        var now  = getCurrentMoment();
+        $('.timeboxL').each(function(i, e) {
+            var $e = $(e);
+            var datetime = $e.data('datetime');
+            // Skip in case datetime attribute is not there
+            if (datetime == null) {
+                return true;
+            }
+            var d = moment(datetime);
+            if (prevSession.moment) {
+                var isActiveSession = now.isBetween(prevSession.moment, d);
+                prevSession.$element.parent().toggleClass("active-session", isActiveSession);
+            }
+            prevSession = {
+                moment: d,
+                $element: $e
+            }
+        });
+
+        // Also check the last session
+        if (prevSession.moment) {
+            const lastSessionDurationMinutes = 45;
+            var endOfSession = prevSession.moment.clone().add(lastSessionDurationMinutes, 'minutes');
+            var isActiveSession = now.isBetween(prevSession.moment, endOfSession);
+            prevSession.$element.parent().toggleClass("active-session", isActiveSession);
+        }
+    }
+
+    function getCurrentMoment() {
+        // For testing, hardcode current time
+        // var now  = moment('2022-07-22T16:03:01Z');
+        // var now  = moment('2022-07-24T21:59:01Z');
+
+        // For production, get actual current time
+        var now  = moment();
+        return now;
+    }
+
+    function setLocalTime() {
         // Find all timeboxL elements and display their time.
         $('.timeboxL').each(function(i, e) {
             var $e = $(e);
@@ -837,12 +882,13 @@ $( document ).ready(function() {
         });
     }
 
-    set_local_time()
+    setLocalTime()
     displayUserTimezone();
     // To prevent initial flickering, show user time on load
     displayUserTime();
     setInterval(function() {
-        displayUserTime()
+        displayUserTime();
+        markActiveSession();
     }, 1000);
     togglePoshlets(getPoshletsState());
 

--- a/program.html.in
+++ b/program.html.in
@@ -93,7 +93,7 @@ $( document ).ready(function() {
 
     timezone.oninput = function () {
         moment.tz.setDefault(this.value)
-        set_local_time()
+        setLocalTime()
     }
     const poshletClasses = ".latex, .tex, .xetexwithsub, .xetex, .xesomething";
 
@@ -109,7 +109,52 @@ $( document ).ready(function() {
         $('#yourTime').html(timeString);
     }
 
-    function set_local_time() {
+    /**
+     * Goes through all items (sessions) and marks the 'current' one as "active-session".
+     * This would affect its appearance (blinking background)
+     */
+    function markActiveSession() {
+        var prevSession = {};
+
+        var now  = getCurrentMoment();
+        $('.timeboxL').each(function(i, e) {
+            var $e = $(e);
+            var datetime = $e.data('datetime');
+            // Skip in case datetime attribute is not there
+            if (datetime == null) {
+                return true;
+            }
+            var d = moment(datetime);
+            if (prevSession.moment) {
+                var isActiveSession = now.isBetween(prevSession.moment, d);
+                prevSession.$element.parent().toggleClass("active-session", isActiveSession);
+            }
+            prevSession = {
+                moment: d,
+                $element: $e
+            }
+        });
+
+        // Also check the last session
+        if (prevSession.moment) {
+            const lastSessionDurationMinutes = 45;
+            var endOfSession = prevSession.moment.clone().add(lastSessionDurationMinutes, 'minutes');
+            var isActiveSession = now.isBetween(prevSession.moment, endOfSession);
+            prevSession.$element.parent().toggleClass("active-session", isActiveSession);
+        }
+    }
+
+    function getCurrentMoment() {
+        // For testing, hardcode current time
+        // var now  = moment('2022-07-22T16:03:01Z');
+        // var now  = moment('2022-07-24T21:59:01Z');
+
+        // For production, get actual current time
+        var now  = moment();
+        return now;
+    }
+
+    function setLocalTime() {
         // Find all timeboxL elements and display their time.
         $('.timeboxL').each(function(i, e) {
             var $e = $(e);
@@ -126,12 +171,13 @@ $( document ).ready(function() {
         });
     }
 
-    set_local_time()
+    setLocalTime()
     displayUserTimezone();
     // To prevent initial flickering, show user time on load
     displayUserTime();
     setInterval(function() {
-        displayUserTime()
+        displayUserTime();
+        markActiveSession();
     }, 1000);
     togglePoshlets(getPoshletsState());
 


### PR DESCRIPTION
Based on the current time, the session start time and the next session's start time, highlight the current active session.
To test, temporarily "hack" the `getCurrentMoment` function and provide the desired 'current' time.

Note: in my previous change, I forgot to include `program.html.in`. I've closed the previous pull request, and this one replaces it.